### PR TITLE
Fix: build failed because of type mismatch

### DIFF
--- a/help/INSTALL-ANDROID.md
+++ b/help/INSTALL-ANDROID.md
@@ -44,7 +44,7 @@ import io.flutter.app.FlutterApplication;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
-class Application : FlutterApplication(), PluginRegistrantCallback {
+class Application : FlutterApplication(), PluginRegistry.PluginRegistrantCallback {
   override fun onCreate() {
     super.onCreate();
     BackgroundFetchPlugin.setPluginRegistrant(this);


### PR DESCRIPTION
If you copy and paste the Kotlin_part, gradle_build fails because PluginRegistry.PluginRegistrantCallback is expected. 
I've added PluginRegistry., so everything works again.