### PR TITLE
Fix typo in config map

### DIFF
--- a/lib/background_fetch.dart
+++ b/lib/background_fetch.dart
@@ -163,7 +163,7 @@ class BackgroundFetchConfig {
       config['requiresStorageNotLow'] = requiresStorageNotLow;
     if (requiresCharging != null) config['requiresCharging'] = requiresCharging;
     if (requiresDeviceIdle != null)
-      config['requiresDeviceIdle'] = requiresBatteryNotLow;
+      config['requiresDeviceIdle'] = requiresDeviceIdle;
 
     return config;
   }


### PR DESCRIPTION
The `requiresDeviceIdle` value is incorrect.