### PR TITLE
Update version in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Android plugin provides a [Headless](https://pub.dartlang.org/documentation/
 
 ```yaml
 dependencies:
-  background_fetch: '^0.2.0'
+  background_fetch: '^0.4.0'
 ```
 
 ### Or latest from Git:


### PR DESCRIPTION
Version had to be updated in README.md. Version 0.2.0 gives errors with parameters that version 0.4.0 includes in BackgroundFetchConfig.