### PR TITLE
Fix README cross references

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ Background Fetch is a *very* simple plugin which will awaken an app in the backg
 # Contents
 
 - ### 📚 [API Documentation](https://pub.dartlang.org/documentation/background_fetch/latest/background_fetch/BackgroundFetch-class.html)
-- ### [Installing the Plugin](#large_blue_diamond-installing-the-plugin)
-- ### [Setup Guides](#large_blue_diamond-setup-guides)
-- ### [Example](#large_blue_diamond-example)
-- ### [Debugging](#large_blue_diamond-debugging)
-- ### [Demo Application](#large_blue_diamond-demo-application)
+- ### [Installing the Plugin](#-installing-the-plugin)
+- ### [Setup Guides](#-setup-guides)
+- ### [Example](#-example)
+- ### [Debugging](#-debugging)
+- ### [Demo Application](#-demo-application)
+- ### [Implementation](#-implementation)
+- ### [Licence](#-licence)
 
 ## 🔷 Installing the plugin
 


### PR DESCRIPTION
Trying to navigate through the contents of README got me frustrated. Cross references don't seem to work on both GitHub and Pub. I fixed that by removing the prefix _large_blue_diamond_ (the emoji) from anchor name, which is ignored by markdown.

Also, I did notice that [Implementation](https://github.com/transistorsoft/flutter_background_fetch#-implementation) and [Licence](https://github.com/transistorsoft/flutter_background_fetch#-licence) were not comprised by [Contents](https://github.com/transistorsoft/flutter_background_fetch#contents). I'm not sure whether this is intended or not, and couldn't find any PR that proposed any related change, so I added them. Please, let me know if this is not what you expect (perhaps those contents are not relevant), so I can removed them.