### PR TITLE
Function Type Specification for Headless Tasks, onFetch and onTimeout

### DIFF
--- a/lib/background_fetch.dart
+++ b/lib/background_fetch.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 const _PLUGIN_PATH = "com.transistorsoft/flutter_background_fetch";
 const _METHOD_CHANNEL_NAME = "$_PLUGIN_PATH/methods";
@@ -418,8 +418,9 @@ class BackgroundFetch {
   ///   BackgroundFetch.finish(taskId);
   /// })
   /// ```
-  static Future<int> configure(BackgroundFetchConfig config, Function onFetch,
-      [Function? onTimeout]) {
+  static Future<int> configure(
+      BackgroundFetchConfig config, Function(String taskId) onFetch,
+      [Function(String taskId)? onTimeout]) {
     if (_eventsFetch == null) {
       _eventsFetch = _eventChannelTask.receiveBroadcastStream();
       if (onTimeout == null) {
@@ -605,7 +606,8 @@ class BackgroundFetch {
   /// }
   /// ```
   ///
-  static Future<bool> registerHeadlessTask(Function callback) async {
+  static Future<bool> registerHeadlessTask(
+      Function(HeadlessTask task) callback) async {
     Completer completer = Completer<bool>();
 
     // Two callbacks:  the provided headless-task + _headlessRegistrationCallback


### PR DESCRIPTION
Hello, 

W.r.t to issue #227 . Here is a PR that implements the suggested changes.


** Improved the function type specification of BackgroundFetch.regist…erHeadlessTask from "BackgroundFetch.registerHeadlessTask(Function callback)" to "BackgroundFetch.registerHeadlessTask(Function(HeadlessTask) callback)"

** also improved the BackgroundFetch.configure parameter "onFetch" Function declaration from "Function onFetch" to "Function(String taskId) onFetch". A similar thing was done for the "onTimeout" parameter