### PR TITLE
Fix cast error on BackgroundFetch.start

### DIFF
--- a/lib/background_fetch.dart
+++ b/lib/background_fetch.dart
@@ -470,7 +470,7 @@ class BackgroundFetch {
     }).catchError((dynamic e) {
       var message = "Unknown error";
       if (e.details != null) {
-        message = e.details;
+        message = e.details.toString();
       }
       completer.completeError(message);
     });


### PR DESCRIPTION
* fixes #277
* errors during start always return an int on iOS, resulting in a cast error 

This is just a minimal invasive fix, the error message doesn't really make sense. 
Not sure what is returned on Android. 