### PR TITLE
fix: null reference crash in BackgroundFetchModule

### DIFF
--- a/android/src/main/java/com/transistorsoft/flutter/backgroundfetch/BackgroundFetchModule.java
+++ b/android/src/main/java/com/transistorsoft/flutter/backgroundfetch/BackgroundFetchModule.java
@@ -88,7 +88,9 @@ public class BackgroundFetchModule implements MethodCallHandler {
             mEventChannelTask.setStreamHandler(mFetchCallback);
         } else {
             LifecycleManager.getInstance().setHeadless(true);
-            mEventChannelTask.setStreamHandler(null);
+            if (mEventChannelTask != null) {
+                mEventChannelTask.setStreamHandler(null);
+            }
             mEventChannelTask = null;
         }
     }


### PR DESCRIPTION
Background Location Geolocation Plugin user here - found this while tracking down some crashes.

If the Activity is rapidly started and stopped - `mEventChannelTask` can be null. 

This can happen when a user taps the 'back' navigation button on some Android distros and then opens the app again quickly.

With this null check implemented, we no longer see the below (some info redacted): 

```
E/AndroidRuntime(17025): java.lang.RuntimeException: Unable to destroy activity {app.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void io.flutter.plugin.common.EventChannel.setStreamHandler(io.flutter.plugin.common.EventChannel$StreamHandler)' on a null object reference
E/AndroidRuntime(17025): 	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5433)
E/AndroidRuntime(17025): 	at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5466)
E/AndroidRuntime(17025): 	at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:47)
E/AndroidRuntime(17025): 	at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
E/AndroidRuntime(17025): 	at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
E/AndroidRuntime(17025): 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
E/AndroidRuntime(17025): 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2308)
E/AndroidRuntime(17025): 	at android.os.Handler.dispatchMessage(Handler.java:106)
E/AndroidRuntime(17025): 	at android.os.Looper.loopOnce(Looper.java:201)
E/AndroidRuntime(17025): 	at android.os.Looper.loop(Looper.java:288)
E/AndroidRuntime(17025): 	at android.app.ActivityThread.main(ActivityThread.java:7898)
E/AndroidRuntime(17025): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(17025): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
E/AndroidRuntime(17025): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
E/AndroidRuntime(17025): Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void io.flutter.plugin.common.EventChannel.setStreamHandler(io.flutter.plugin.common.EventChannel$StreamHandler)' on a null object reference
E/AndroidRuntime(17025): 	at com.transistorsoft.flutter.backgroundfetch.BackgroundFetchModule.setActivity(BackgroundFetchModule.java:91)
E/AndroidRuntime(17025): 	at com.transistorsoft.flutter.backgroundfetch.BackgroundFetchPlugin.onDetachedFromActivity(BackgroundFetchPlugin.java:60)
E/AndroidRuntime(17025): 	at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.detachFromActivity(FlutterEngineConnectionRegistry.java:383)
E/AndroidRuntime(17025): 	at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onDetach(FlutterActivityAndFragmentDelegate.java:681)
E/AndroidRuntime(17025): 	at io.flutter.embedding.android.FlutterActivity.onDestroy(FlutterActivity.java:715)
E/AndroidRuntime(17025): 	at android.app.Activity.performDestroy(Activity.java:8547)
E/AndroidRuntime(17025): 	at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1419)
E/AndroidRuntime(17025): 	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5420)
E/AndroidRuntime(17025): 	... 13 more
E/TSLocationManager(17025): [c.t.l.a.BackgroundGeolocation$w0 uncaughtException]
E/TSLocationManager(17025):   ‼️  Uncaught Exception: Unable to destroy activity {app.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void io.flutter.plugin.common.EventChannel.setStreamHandler(io.flutter.plugin.common.EventChannel$StreamHandler)' on a null object reference
```