### PR TITLE
iOS: add early BGTaskScheduler registration hook

### DIFF
--- a/help/INSTALL-IOS.md
+++ b/help/INSTALL-IOS.md
@@ -55,6 +55,33 @@ BackgroundFetch.scheduleTask(TaskConfig(
 
 ```
 
+## Flutter 3.41+ UIScene lifecycle
+
+If your app has adopted Flutter's UIScene lifecycle, the plugin application lifecycle fallback can be delivered too late for `BGTaskScheduler`.
+iOS requires all launch handlers to be registered before application launch finishes.  In that case, call
+`BackgroundFetchPlugin.registerBackgroundTasksIfNeeded()` from your real `AppDelegate.didFinishLaunchingWithOptions` before returning from `super`.
+
+```swift
+import Flutter
+import UIKit
+import background_fetch
+
+@main
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    BackgroundFetchPlugin.registerBackgroundTasksIfNeeded()
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+  }
+}
+```
+
 <!--
 ## Privacy Manifest
 

--- a/ios/background_fetch/Sources/background_fetch/BackgroundFetchPlugin.m
+++ b/ios/background_fetch/Sources/background_fetch/BackgroundFetchPlugin.m
@@ -22,6 +22,8 @@ static NSString *const ACTION_SCHEDULE_TASK = @"scheduleTask";
 @interface BackgroundFetchPlugin ()<FlutterStreamHandler>
 @end
 
+static BOOL didRegisterBackgroundFetchTasks = NO;
+
 @implementation BackgroundFetchPlugin {
     FlutterEventSink eventSink;
 }
@@ -34,8 +36,22 @@ static NSString *const ACTION_SCHEDULE_TASK = @"scheduleTask";
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [[TSBackgroundFetch sharedInstance] didFinishLaunching];
+    [BackgroundFetchPlugin registerBackgroundTasksIfNeeded];
     return YES;
+}
+
++ (void)registerBackgroundTasksIfNeeded {
+    @synchronized (self) {
+        if (didRegisterBackgroundFetchTasks) {
+            return;
+        }
+
+        // BGTaskScheduler requires all launch handlers to be registered before application launch finishes.
+        // Flutter 3.41's UIScene fallback can deliver the plugin lifecycle callback after that point, so
+        // allow AppDelegate to invoke this method from the real didFinishLaunching phase.
+        didRegisterBackgroundFetchTasks = YES;
+        [[TSBackgroundFetch sharedInstance] didFinishLaunching];
+    }
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {

--- a/ios/background_fetch/Sources/background_fetch/include/background_fetch/BackgroundFetchPlugin.h
+++ b/ios/background_fetch/Sources/background_fetch/include/background_fetch/BackgroundFetchPlugin.h
@@ -1,4 +1,5 @@
 #import <Flutter/Flutter.h>
 
 @interface BackgroundFetchPlugin : NSObject<FlutterPlugin>
++ (void)registerBackgroundTasksIfNeeded;
 @end


### PR DESCRIPTION
Fixes #414

## Summary

This PR adds an idempotent iOS registration hook for `TSBackgroundFetch.didFinishLaunching`:

- Adds `BackgroundFetchPlugin.registerBackgroundTasksIfNeeded()`
- Reuses that hook from the existing plugin `application:didFinishLaunchingWithOptions:` callback
- Documents the Flutter 3.41+ UIScene setup where apps can call the hook from the real `AppDelegate.didFinishLaunchingWithOptions`

## Why

With Flutter 3.41's UIScene lifecycle, the Flutter plugin application lifecycle fallback can be delivered from the scene path after application launch has already finished. On iOS, `BGTaskScheduler` requires all launch handlers to be registered before application launch completes. If `TSBackgroundFetch.didFinishLaunching` is invoked too late, iOS can throw:

```text
NSInternalInconsistencyException
All launch handlers must be registered before application finishes launching
```

This hook lets UIScene-based apps register the background task handler early from the real app launch phase, while keeping the existing plugin lifecycle callback safe through the same idempotent path.

## Validation

Tested in a downstream Flutter 3.41.6 app with:

```text
flutter build ios --simulator
```